### PR TITLE
Feat: Add strict decorator

### DIFF
--- a/figenv.py
+++ b/figenv.py
@@ -87,20 +87,17 @@ class MetaConfig(type):
         if (not load_all and name not in cls._dict) or (name not in cls._dict and prefix + name not in os.environ):
             raise AttributeError(f"type object {cls.name} has no attribute '{name}'")
 
-        value = cls._dict.get(name, _MISSING)
+        value = cls._dict.get(name, None)
 
         override_via_environment = True
         if callable(value) and getattr(value, "_strict", False):
-                override_via_environment = False
+            override_via_environment = False
 
         if override_via_environment and prefix + name in os.environ:
             value = os.environ[prefix + name]
 
         if callable(value):
             value = value(cls)
-
-        if value is _MISSING:
-            raise AttributeError(f"type object {cls.name} has no attribute '{name}'")
 
         annotation = getattr(cls, '__annotations__', {}).get(name, None)
         if annotation is not None:

--- a/figenv.py
+++ b/figenv.py
@@ -90,8 +90,7 @@ class MetaConfig(type):
         value = cls._dict.get(name, _MISSING)
 
         override_via_environment = True
-        if callable(value):
-            if hasattr(value, "_strict") and value._strict:
+        if callable(value) and getattr(value, "_strict", False):
                 override_via_environment = False
 
         if override_via_environment and prefix + name in os.environ:

--- a/test.py
+++ b/test.py
@@ -3,7 +3,7 @@ import os
 import typing
 import unittest
 
-from figenv import MetaConfig
+from figenv import MetaConfig, strict
 
 
 class TestEnv(unittest.TestCase):
@@ -215,6 +215,29 @@ class TestEnv(unittest.TestCase):
         TestConfiguration = self._get_test_configuration(DATA='blah', FUNC=func)
         self.assertEqual(TestConfiguration.FUNC, 'blah123')
         assert 'FUNC' in dir(TestConfiguration)
+
+    def test_override_from_env_functions(self):
+        """A test to ensure that functions are overridden with environment values"""
+
+        def func(cls):
+            return cls.DATA + ' world'
+
+        with self.with_env(GREETING='hola mundo'):
+            TestConfiguration = self._get_test_configuration(DATA='hello', GREETING=func)
+            assert 'GREETING' in dir(TestConfiguration)
+            self.assertEqual(TestConfiguration.GREETING, 'hola mundo')
+
+    def test_strict_functions(self):
+        """A test to ensure that strict functions are NOT overridden with environment values"""
+
+        @strict
+        def func(cls):
+            return cls.DATA + ' world'
+
+        with self.with_env(GREETING='hola mundo'):
+            TestConfiguration = self._get_test_configuration(DATA='hello', GREETING=func)
+            assert 'GREETING' in dir(TestConfiguration)
+            self.assertEqual(TestConfiguration.GREETING, 'hello world')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a decorator to allow disabling the default behaviour of overriding function configuration values with environmental variables

Example
```
class Config(metaclass=MetaConfig)
    USER_NAME: str = "test"
    PASSWORD: str = "test"
    
    def CREDENTIALS(cls):
        return cls.USER_NAME + ":" + cls.PASSWORD
        
     @strict
     def STRICT_CREDENTIALS(cls):
         return cls.USER_NAME + ":" + cls.PASSWORD
```

```
>> os.environ["CREDENTIALS"] = "fake:creds"
>> os.environ["STRICT_CREDENTIALS"] = "fake:creds"
>> Config.CREDENTIALS
"fake:creds"
>> Config.STRICT_CREDENTIALS
"test:test"
```