### PR TITLE
Feat: Support settings with no default

### DIFF
--- a/figenv.py
+++ b/figenv.py
@@ -14,6 +14,14 @@ import os
 _MISSING = type("MISSING", (object,), {"__repr__": lambda self: "<MISSING CONFIGURATION>"})()
 
 
+class MissingConfigurationException(RuntimeError):
+    def __init__(self, name, message=None):
+        self.name = name
+        if not message:
+            message = f"Configuration '{self.name}' is not present in environment"
+        super().__init__(message)
+
+
 def _check_special_names(name):
     return name in ('name', 'keys') or name.startswith('_')
 
@@ -110,7 +118,7 @@ class MetaConfig(type):
 
         if value == _MISSING:
             # Configuration with no default and no value in the environment
-            raise RuntimeError(f"Configuration '{name}' is not present in environment and has no default")
+            raise MissingConfigurationException(name)
 
         if callable(value):
             value = value(cls)

--- a/test.py
+++ b/test.py
@@ -63,6 +63,8 @@ class TestEnv(unittest.TestCase):
         self.assertIs(TestConfiguration.BOOL_SETTING, True)
         with self.assertRaises(RuntimeError):
             TestConfiguration.NO_DEFAULT_SETTING
+        with self.assertRaises(RuntimeError):
+            TestConfiguration["NO_DEFAULT_SETTING"]
 
     def test_invalid_setter(self):
         """users should not be able to set variables using attributes"""

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ import unittest
 
 import xmlrunner
 
-from figenv import MetaConfig, strict
+from figenv import MetaConfig, strict, MissingConfigurationException, _MISSING
 
 
 class TestEnv(unittest.TestCase):
@@ -255,6 +255,24 @@ class TestEnv(unittest.TestCase):
             TestConfiguration = self._get_test_configuration(DATA='hello', GREETING=func)
             assert 'GREETING' in dir(TestConfiguration)
             self.assertEqual(TestConfiguration.GREETING, 'hello world')
+
+
+class TestMissing(unittest.TestCase):
+    """Pointless tests for code coverage"""
+
+    def test_representation(self):
+        value = _MISSING
+        self.assertEqual(str(value), "<MISSING CONFIGURATION>")
+
+    def test_exception_default(self):
+        exception = MissingConfigurationException("MY_VALUE")
+        self.assertEqual(exception.name, "MY_VALUE")
+        self.assertEqual(str(exception), "Configuration 'MY_VALUE' is not present in environment")
+
+    def test_exception_custom_message(self):
+        exception = MissingConfigurationException("MY_VALUE", "Invalid Configuration! Please provide MY_VALUE.")
+        self.assertEqual(exception.name, "MY_VALUE")
+        self.assertEqual(str(exception), "Invalid Configuration! Please provide MY_VALUE.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously there was no way to specify a configuration value without giving a default. Now you can specify a configuration value that must come from the environment. These values will raise a MissingConfigurationException(RuntimeError) if there is no value present in the environment at the time the configuration is evaluated.

Use cases:

- I want to only pull defined values from the environment (ENV_LOAD_ALL = False), but there is not a reasonable default value to use for my configuration.
- I want to require a configuration, and want my application to fail quickly and clearly if that configuration is not present. (A default of None or some other 'missing' value could lead to hard to debug failures instead).
- I am pulling values from the environment (ENV_LOAD_ALL = True), but there are a few that I need specific coercion for and I don't want to worry about defaults.


Example Configuration:
```
class MyConfiguration(metaclass=MetaConfig):
    APPLICATION_SECRET_KEY: str
    APPLICATION_UUID: uuid
    
    @static_method
    def _to_uuid(value):
      return uuid.uuid4(value)
 ```
 
 Example Environment:
 ```
 APPLICATION_SECRET_KEY: "12345abcde"
 APPLICATION_UUID: '7293e8e5-25a3-4319-832a-f813e80c8b6f'
 APPLICATION_NAME: "My Cool Application"
 APPLICATION_VERSION: "1.3.4"
 ```